### PR TITLE
Add MQTT/Domoticz device variant

### DIFF
--- a/Software/Comfospot_50.yaml
+++ b/Software/Comfospot_50.yaml
@@ -468,13 +468,21 @@ script:
       - globals.set:
           id: direction
           value: '0'
+      - script.execute: notify_intake_impossible
+      - delay: 5s # cooldown to not send multiple notifications on error led toggling
+
+  # Notification shown when the intake direction can't be set. Kept in its own
+  # script so API-free builds (e.g. MQTT/Domoticz, no `api:` component) can
+  # override just this part via a package `!remove` instead of duplicating the
+  # whole intake_impossible script. Behaviour for HA builds is unchanged.
+  - id: notify_intake_impossible
+    then:
       - homeassistant.service:
           service: persistent_notification.create
           data:
             title: ${device_name}
           data_template:
             message: Fan direction Intake could not be set (Probably due to cold temperatures outside)
-      - delay: 5s # cooldown to not send multiple notifications on error led toggling
 
 
             

--- a/Software/comfospot-mqtt.yaml
+++ b/Software/comfospot-mqtt.yaml
@@ -1,0 +1,88 @@
+---
+# MQTT variant of the Comfospot 50 controller.
+#
+# Use this instead of lftung_xxx.yaml / Comfospot-dist.yaml when you want to
+# integrate the device via MQTT (e.g. Domoticz) instead of the native
+# Home Assistant API.
+#
+# This is a fully Home-Assistant-free build. The shared Comfospot_50.yaml is
+# reused unchanged; the two HA-specific bits it contains are overridden here
+# via ESPHome package overrides (!remove), so no `api:` component is needed:
+#   * an `mqtt:` block with Home-Assistant-style discovery is added, which
+#     Domoticz' "MQTT Auto Discovery Client Gateway" understands out of the box.
+#   * the time source is switched from `homeassistant` to `sntp` (see `time:`
+#     below), because without the HA API there is no clock to drive the filter
+#     runtime calculation.
+#   * the small `notify_intake_impossible` script (called by intake_impossible
+#     in the package) is overridden (see `script:` below) to replace its
+#     `homeassistant.service` notification call -- which would otherwise require
+#     the `api:` component -- with a plain log line.
+# OTA still works (own `ota:` component); view logs over serial/USB or MQTT.
+substitutions:
+  device_name: Comfospot MQTT
+  friendly_name_fan: Comfospot MQTT
+  gpio_led1: GPIO0
+  gpio_led2: GPIO3
+  gpio_led3: GPIO1
+  gpio_led4: GPIO4
+  gpio_led_filter_change: GPIO10
+  gpio_led_error: GPIO7
+  gpio_output_plus: GPIO5
+  gpio_output_minus: GPIO6
+  gpio_status_led: GPIO8
+packages:
+  restart_buttons: !include restart.yaml
+  comfospot_50: !include Comfospot_50.yaml
+  status led: !include status_led.yaml
+esphome:
+  name: comfospot-mqtt
+  friendly_name: Comfospot MQTT
+  platformio_options:
+    board_build.flash_mode: dio
+    board_build.f_cpu: 80000000L
+esp32:
+  board: esp32-c3-devkitm-1
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_ESP32C3_DEFAULT_CPU_FREQ_MHZ: '80'
+      CONFIG_ESP32C3_DEFAULT_CPU_FREQ_80: y
+# Enable logging
+logger:
+  hardware_uart: USB_SERIAL_JTAG
+ota:
+  platform: esphome
+  password: !secret ota_password
+# MQTT integration for Domoticz / generic brokers.
+mqtt:
+  broker: !secret mqtt_broker
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+  # Domoticz' MQTT Auto Discovery gateway expects this exact prefix.
+  discovery: true
+  discovery_prefix: homeassistant
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: Comfospot-MQTT
+    password: ''
+captive_portal:
+# Override the time source defined in the shared Comfospot_50.yaml package:
+# drop the Home-Assistant-API clock and replace it with NTP, keeping the same
+# id (my_time) so all package scripts keep working unchanged.
+time:
+  - id: !remove my_time
+  - platform: sntp
+    id: my_time
+    timezone: Europe/Berlin
+# Override only the notification helper from the shared package: drop the
+# homeassistant.service call (which needs the api: component) and log instead.
+# intake_impossible itself stays in the package and keeps calling this script.
+script:
+  - id: !remove notify_intake_impossible
+  - id: notify_intake_impossible
+    then:
+      - logger.log: "Fan direction Intake could not be set on ${device_name} (probably due to cold temperatures outside)"

--- a/Software/secrets.example.yaml
+++ b/Software/secrets.example.yaml
@@ -3,3 +3,6 @@ wifi_ssid: My SSID
 wifi_password: My WIFI Password
 api_encryption_key: My API Encryption Key
 ota_password: My OTA Password
+mqtt_broker: 192.168.1.10
+mqtt_username: My MQTT User
+mqtt_password: My MQTT Password


### PR DESCRIPTION
## What

Adds a standalone device config, `Software/comfospot-mqtt.yaml`, that integrates the Comfospot 50 controller via **MQTT** (e.g. Domoticz) instead of the native Home Assistant API, using HA-style MQTT auto-discovery (`discovery_prefix: homeassistant`, understood by Domoticz' "MQTT Auto Discovery Client Gateway" out of the box).

## Why

Domoticz has no support for the native ESPHome/HA API but a mature MQTT auto-discovery client, so MQTT is the natural integration path. A fully Home-Assistant-free build is desirable so no unused `api:` component is required.

## How

The new variant reuses the shared `Comfospot_50.yaml` package and overrides only the two HA-specific bits via ESPHome package overrides (`!remove`), so it needs **no `api:` component**:

- **time**: source switched from `homeassistant` to `sntp` — without the HA API there is no clock to drive the filter-runtime calculation.
- **notify_intake_impossible**: the `homeassistant.service` notification (which requires `api:`) is replaced with a plain log line.

To keep that override to ~3 lines instead of duplicating the whole ~15-line `intake_impossible` script, the `persistent_notification` call is extracted from `intake_impossible` into its own small `notify_intake_impossible` script in the shared package. **This is behaviour-neutral for existing HA installs** — same notification, same cooldown.

`secrets.example.yaml` gains `mqtt_broker` / `mqtt_username` / `mqtt_password`.

## Reviewer notes

- Core logic stays single-source; MQTT-build duplication is down to 3 lines.
- Both the new MQTT variant and the existing `lftung_xxx.yaml` HA variant pass `esphome config`.
- OTA still works via the `ota:` component; logs are available over serial/USB or MQTT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)